### PR TITLE
Fixed version string according to semver(1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "p2Pixi",
-    "version": "0.81",
+    "version": "0.8.1",
     "description": "A simple 2D vector game model framework using p2.js for physics and Pixi.js for rendering.",
     "author": "Tom W Hall <tomshalls@gmail.com>",
     "keywords": [


### PR DESCRIPTION
Fixed the version string.
npm could not install the package p2Pixi due to an unparsable version string.
